### PR TITLE
Create Titration curve from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ For more info check [CONTRIBUTING](./CONTRIBUTING.rst)
 ## Contacts
 
   Please submit a github issue to report bugs and to request new features.
-  Alternatively you may find the developer [here](mailto:pdreis@fc.ul.pt). Please visit ou [website](http://mms.rd.ciencias.ulisboa.pt/) for more information.
+  Alternatively you may find the developer [here](mailto:pdreis@fc.ul.pt). Please visit ou [website](https://mms.rd.ciencias.ulisboa.pt/) for more information.

--- a/docs/source/getting_started/example_full.rst
+++ b/docs/source/getting_started/example_full.rst
@@ -13,11 +13,12 @@ Complete Parameters File Template
    sites = all             # Titrate all available sites
    
    # Output
-   output = pKas.txt                     # pKa values output file
-   titration_output = titration.txt      # Titration curves output file
-   isoelectric_point = yes               # Calculate isoelectric point
-   save_pdb = pb_input.pdb               # save PB input file
-   structure_output = out.pdb, 7, amber  # Output structure with the most likely protonation state at a given pH value
+   output = pKas.txt                       # pKa values output file
+   titration_output = titration.txt        # Titration curves output file
+   titration_curve = titration_curve.txt   # Full titration curve (whole system charge) output file
+   isoelectric_point = yes                 # Calculate isoelectric point
+   save_pdb = pb_input.pdb                 # save PB input file
+   structure_output = out.pdb, 7, amber    # Output structure with the most likely protonation state at a given pH value
    # filename, pH value, force field ("gromos_cph", "amber")
    
    

--- a/pypka/config.py
+++ b/pypka/config.py
@@ -108,6 +108,7 @@ class ParametersDict:
         "output": "f_out",
         "logfile": "f_log",
         "titration_output": "f_prot_out",
+        "titration_curve": "f_all_prot_out",
         "clean": "clean_pdb",
     }
 
@@ -245,6 +246,7 @@ class PypKaConfig(ParametersDict):
         self.f_in_extension = None
         self.f_out = None
         self.f_prot_out = None
+        self.f_all_prot_out = None
         self.f_structure_out = None
 
         # Output File
@@ -295,6 +297,7 @@ class PypKaConfig(ParametersDict):
             "f_in": str,
             "f_out": str,
             "f_prot_out": str,
+            "f_all_prot_out": str,
             "f_structure_out": str,
             "f_structure_out_pH": float,
             "ff_structure_out": str,

--- a/pypka/main.py
+++ b/pypka/main.py
@@ -589,6 +589,11 @@ class Titration:
         if Config.pypka_params["f_prot_out"]:
             with open(Config.pypka_params["f_prot_out"], "w") as f:
                 f.write(mc.text_prots)
+        if Config.pypka_params["f_all_prot_out"]:
+            titration_curve = self.getTitrationCurve()
+            text_tit_curve = "\n".join(f"{pH}\t{value}" for pH, value in titration_curve.items())
+            with open(Config.pypka_params["f_all_prot_out"], "w") as f:
+                f.write(text_tit_curve)
         if Config.pypka_params["coupled_sites_output"]:
             with open(Config.pypka_params["coupled_sites_output"], "w") as f:
                 f.write(mc.text_coupled_sites)

--- a/pypka/mc/run_mc.py
+++ b/pypka/mc/run_mc.py
@@ -178,6 +178,7 @@ class MonteCarlo:
         self.text_pks = text_pks
         self.text_prots = text_prots
 
+
     def get_tit_states(self):
         mcsteps = Config.mc_params["mcsteps"]
 

--- a/pypka/mc/run_mc.py
+++ b/pypka/mc/run_mc.py
@@ -178,7 +178,6 @@ class MonteCarlo:
         self.text_pks = text_pks
         self.text_prots = text_prots
 
-
     def get_tit_states(self):
         mcsteps = Config.mc_params["mcsteps"]
 


### PR DESCRIPTION
Creates a new option to be given in the parameters.dat file: " titration_curve = filename", that will output the full titration curve of the system in the pH range and step that was user defined.